### PR TITLE
Update host/port parsing to support IPv6 addresses.

### DIFF
--- a/src/cluster/connectionBuilder.js
+++ b/src/cluster/connectionBuilder.js
@@ -67,6 +67,7 @@ module.exports = ({
         `Failed to connect: "config.brokers" returned void or empty array`
       )
     }
+
     return list
   }
 
@@ -77,8 +78,15 @@ module.exports = ({
 
         const randomBroker = list[index++ % list.length]
 
-        host = randomBroker.split(':')[0]
-        port = Number(randomBroker.split(':')[1])
+        // awhittier: Works for myserver:9902, 10.1.2.3:9902, and ::1:9902.
+        const lastColonIdx = randomBroker.lastIndexOf(':')
+        if (lastColonIdx === -1 || lastColonIdx === randomBroker.length - 1) {
+          throw new KafkaJSNonRetriableError(
+            `Failed to connect: host ${randomBroker} did not contain a host and port separated by a colon`
+          )
+        }
+        host = randomBroker.substring(0, lastColonIdx)
+        port = Number(randomBroker.substring(lastColonIdx + 1))
       }
 
       return new Connection({


### PR DESCRIPTION
Previously, the code we inherited from kafkajs just split host/port on the first ':' it found for a broker, so ipv6 addresses like ::1 would completely confuse it. This code splits on the last ':' it finds, so it should work for hostnames, IPv4 addresses, and IPv6 addresses.

I considered using a regex but splitting on the last colon gives the same results and is simpler. 